### PR TITLE
158031250-manual fix wsdl to ts to correct type recognition

### DIFF
--- a/dist/lib/clients.d.ts
+++ b/dist/lib/clients.d.ts
@@ -24,16 +24,16 @@ export declare function createNodoChiediElencoAvvisiDigitaliClient(options: soap
 export declare class PagamentiTelematiciPspNodoAsyncClient {
     private readonly client;
     constructor(client: PagamentiTelematiciPspNodoService.IPPTPortSoap);
-    nodoVerificaRPT: (input: PagamentiTelematiciPspNodoService.InodoVerificaRPTInput) => Promise<PagamentiTelematiciPspNodoService.InodoVerificaRPTOutput>;
-    nodoAttivaRPT: (input: PagamentiTelematiciPspNodoService.InodoAttivaRPTInput) => Promise<PagamentiTelematiciPspNodoService.InodoAttivaRPTOutput>;
-    nodoInviaRT: (input: PagamentiTelematiciPspNodoService.InodoInviaRTInput) => Promise<PagamentiTelematiciPspNodoService.InodoInviaRTOutput>;
-    nodoChiediInformativaPA: (input: PagamentiTelematiciPspNodoService.InodoChiediInformativaPAInput) => Promise<PagamentiTelematiciPspNodoService.InodoChiediInformativaPAOutput>;
-    nodoChiediTemplateInformativaPSP: (input: PagamentiTelematiciPspNodoService.InodoChiediTemplateInformativaPSPInput) => Promise<PagamentiTelematiciPspNodoService.InodoChiediTemplateInformativaPSPOutput>;
-    nodoInviaFlussoRendicontazione: (input: PagamentiTelematiciPspNodoService.InodoInviaFlussoRendicontazioneInput) => Promise<PagamentiTelematiciPspNodoService.InodoInviaFlussoRendicontazioneOutput>;
-    nodoChiediElencoQuadraturePSP: (input: PagamentiTelematiciPspNodoService.InodoChiediElencoQuadraturePSPInput) => Promise<PagamentiTelematiciPspNodoService.InodoChiediElencoQuadraturePSPOutput>;
-    nodoChiediQuadraturaPSP: (input: PagamentiTelematiciPspNodoService.InodoChiediQuadraturaPSPInput) => Promise<PagamentiTelematiciPspNodoService.InodoChiediQuadraturaPSPOutput>;
-    nodoInviaEsitoStorno: (input: PagamentiTelematiciPspNodoService.InodoInviaEsitoStornoInput) => Promise<PagamentiTelematiciPspNodoService.InodoInviaEsitoStornoOutput>;
-    nodoInviaRichiestaRevoca: (input: PagamentiTelematiciPspNodoService.InodoInviaRichiestaRevocaInput) => Promise<PagamentiTelematiciPspNodoService.InodoInviaRichiestaRevocaOutput>;
+    nodoVerificaRPT: import("./utils").SoapMethodPromise<PagamentiTelematiciPspNodoService.InodoVerificaRPTInput, PagamentiTelematiciPspNodoService.InodoVerificaRPTOutput>;
+    nodoAttivaRPT: import("./utils").SoapMethodPromise<PagamentiTelematiciPspNodoService.InodoAttivaRPTInput, PagamentiTelematiciPspNodoService.InodoAttivaRPTOutput>;
+    nodoInviaRT: import("./utils").SoapMethodPromise<PagamentiTelematiciPspNodoService.InodoInviaRTInput, PagamentiTelematiciPspNodoService.InodoInviaRTOutput>;
+    nodoChiediInformativaPA: import("./utils").SoapMethodPromise<PagamentiTelematiciPspNodoService.InodoChiediInformativaPAInput, PagamentiTelematiciPspNodoService.InodoChiediInformativaPAOutput>;
+    nodoChiediTemplateInformativaPSP: import("./utils").SoapMethodPromise<PagamentiTelematiciPspNodoService.InodoChiediTemplateInformativaPSPInput, PagamentiTelematiciPspNodoService.InodoChiediTemplateInformativaPSPOutput>;
+    nodoInviaFlussoRendicontazione: import("./utils").SoapMethodPromise<PagamentiTelematiciPspNodoService.InodoInviaFlussoRendicontazioneInput, PagamentiTelematiciPspNodoService.InodoInviaFlussoRendicontazioneOutput>;
+    nodoChiediElencoQuadraturePSP: import("./utils").SoapMethodPromise<PagamentiTelematiciPspNodoService.InodoChiediElencoQuadraturePSPInput, PagamentiTelematiciPspNodoService.InodoChiediElencoQuadraturePSPOutput>;
+    nodoChiediQuadraturaPSP: import("./utils").SoapMethodPromise<PagamentiTelematiciPspNodoService.InodoChiediQuadraturaPSPInput, PagamentiTelematiciPspNodoService.InodoChiediQuadraturaPSPOutput>;
+    nodoInviaEsitoStorno: import("./utils").SoapMethodPromise<PagamentiTelematiciPspNodoService.InodoInviaEsitoStornoInput, PagamentiTelematiciPspNodoService.InodoInviaEsitoStornoOutput>;
+    nodoInviaRichiestaRevoca: import("./utils").SoapMethodPromise<PagamentiTelematiciPspNodoService.InodoInviaRichiestaRevocaInput, PagamentiTelematiciPspNodoService.InodoInviaRichiestaRevocaOutput>;
 }
 /**
  * Converts the callback based methods of a IscrizioniAvvisatura client to
@@ -42,7 +42,7 @@ export declare class PagamentiTelematiciPspNodoAsyncClient {
 export declare class IscrizioniAvvisaturaAsyncClient {
     private readonly client;
     constructor(client: IscrizioniAvvisaturaService.IPPTPortSoap);
-    nodoAggiornaIscrizioniAvvisatura: (input: IscrizioniAvvisaturaService.InodoAggiornaIscrizioniAvvisaturaInput) => Promise<IscrizioniAvvisaturaService.InodoAggiornaIscrizioniAvvisaturaOutput>;
+    nodoAggiornaIscrizioniAvvisatura: import("./utils").SoapMethodPromise<IscrizioniAvvisaturaService.InodoAggiornaIscrizioniAvvisaturaInput, IscrizioniAvvisaturaService.InodoAggiornaIscrizioniAvvisaturaOutput>;
 }
 /**
  * Converts the callback based methods of a NodoChiediElencoAvvisiDigitali
@@ -51,5 +51,5 @@ export declare class IscrizioniAvvisaturaAsyncClient {
 export declare class NodoChiediElencoAvvisiDigitaliAsyncClient {
     private readonly client;
     constructor(client: NodoChiediElencoAvvisiDigitaliService.IPPTPortSoap);
-    nodoChiediElencoAvvisiDigitali: (input: NodoChiediElencoAvvisiDigitaliService.InodoChiediElencoAvvisiDigitaliInput) => Promise<NodoChiediElencoAvvisiDigitaliService.InodoChiediElencoAvvisiDigitaliOutput>;
+    nodoChiediElencoAvvisiDigitali: import("./utils").SoapMethodPromise<NodoChiediElencoAvvisiDigitaliService.InodoChiediElencoAvvisiDigitaliInput, NodoChiediElencoAvvisiDigitaliService.InodoChiediElencoAvvisiDigitaliOutput>;
 }

--- a/dist/wsdl-lib/AvvisiDigitaliService/PPTPort.d.ts
+++ b/dist/wsdl-lib/AvvisiDigitaliService/PPTPort.d.ts
@@ -53,7 +53,7 @@ export declare namespace PPTPortTypes {
         /** http://ws.pagamenti.telematici.gov/#stISODate() */
         dataScadenzaAvviso: date;
         /** http://ws.pagamenti.telematici.gov/#stImporto(minInclusive,maxInclusive,fractionDigits,totalDigits) */
-        importoAvviso: "minInclusive" | "maxInclusive" | "fractionDigits" | "totalDigits";
+        importoAvviso: number;
         /** http://ws.pagamenti.telematici.gov/#stEMail(pattern,maxLength) */
         eMailSoggetto: string;
         /** http://ws.pagamenti.telematici.gov/#stCellulareSoggetto(pattern) */

--- a/dist/wsdl-lib/FespPspService/PSPPort.d.ts
+++ b/dist/wsdl-lib/FespPspService/PSPPort.d.ts
@@ -48,7 +48,7 @@ export interface IpspInviaCarrelloRPTCarteInput {
     /** http://ws.pagamenti.telematici.gov/#string(undefined) */
     esitoTransazioneCarta: string;
     /** http://ws.pagamenti.telematici.gov/#stImporto(minInclusive,maxInclusive,fractionDigits,totalDigits) */
-    importoTotalePagato: "minInclusive" | "maxInclusive" | "fractionDigits" | "totalDigits";
+    importoTotalePagato: number;
     /** http://ws.pagamenti.telematici.gov/#stISODateTime() */
     timestampOperazione: dateTime;
     /** http://ws.pagamenti.telematici.gov/#stText6(length) */

--- a/dist/wsdl-lib/NodoChiediElencoAvvisiDigitaliService/PPTPort.d.ts
+++ b/dist/wsdl-lib/NodoChiediElencoAvvisiDigitaliService/PPTPort.d.ts
@@ -52,7 +52,7 @@ export declare namespace PPTPortTypes {
         /** http://ws.pagamenti.telematici.gov/#stISODate() */
         dataScadenzaAvviso: date;
         /** http://ws.pagamenti.telematici.gov/#stImporto(minInclusive,maxInclusive,fractionDigits,totalDigits) */
-        importoAvviso: "minInclusive" | "maxInclusive" | "fractionDigits" | "totalDigits";
+        importoAvviso: number;
         /** http://ws.pagamenti.telematici.gov/#stText140(minLength,maxLength) */
         descrizionePagamento: string;
     }

--- a/dist/wsdl-lib/PagamentiTelematiciPspNodoservice/PPTPort.d.ts
+++ b/dist/wsdl-lib/PagamentiTelematiciPspNodoservice/PPTPort.d.ts
@@ -272,7 +272,7 @@ export declare namespace PPTPortTypes {
         /** http://ws.pagamenti.telematici.gov/#stText25(minLength,maxLength) */
         causaleSpezzone: string;
         /** http://ws.pagamenti.telematici.gov/#stImporto(minInclusive,maxInclusive,fractionDigits,totalDigits) */
-        importoSpezzone: "minInclusive" | "maxInclusive" | "fractionDigits" | "totalDigits";
+        importoSpezzone: number;
     }
     interface IspezzoniCausaleVersamento {
         /** http://ws.pagamenti.telematici.gov/#stText35(minLength,maxLength) */
@@ -281,7 +281,7 @@ export declare namespace PPTPortTypes {
     }
     interface IdatiPagamentoPA {
         /** http://ws.pagamenti.telematici.gov/#stImporto(minInclusive,maxInclusive,fractionDigits,totalDigits) */
-        importoSingoloVersamento: "minInclusive" | "maxInclusive" | "fractionDigits" | "totalDigits";
+        importoSingoloVersamento: number;
         /** http://ws.pagamenti.telematici.gov/#stIBANIdentifier(pattern) */
         ibanAccredito: string;
         /** http://ws.pagamenti.telematici.gov/#stBICIdentifier(pattern) */
@@ -351,7 +351,7 @@ export declare namespace PPTPortTypes {
     }
     interface IdatiPagamentoPSP {
         /** http://ws.pagamenti.telematici.gov/#stImporto(minInclusive,maxInclusive,fractionDigits,totalDigits) */
-        importoSingoloVersamento: "minInclusive" | "maxInclusive" | "fractionDigits" | "totalDigits";
+        importoSingoloVersamento: number;
         /** http://ws.pagamenti.telematici.gov/#stIBANIdentifier(pattern) */
         ibanAppoggio: string;
         /** http://ws.pagamenti.telematici.gov/#stBICIdentifier(pattern) */

--- a/dist/wsdl/avvisatura/sac-common-types-1.0.xsd
+++ b/dist/wsdl/avvisatura/sac-common-types-1.0.xsd
@@ -120,7 +120,7 @@
 
     <xsd:complexType name="ctIdentificativoUnivocoPersonaFG">
         <xsd:sequence>
-            <xsd:element name="tipoIdentificativoUnivoco" type="stTipoIdentificativoUnivocoPersFG" minOccurs="1">
+            <xsd:element form="qualified" name="tipoIdentificativoUnivoco" type="stTipoIdentificativoUnivocoPersFG" minOccurs="1">
                 <xsd:annotation>
                     <xsd:documentation>Campo alfanumerico che indica la natura del
                         soggetto, può assumere i seguenti valori:
@@ -129,7 +129,7 @@
                     <xsd:documentation>G - Persona Giuridica</xsd:documentation>
                 </xsd:annotation>
             </xsd:element>
-            <xsd:element name="codiceIdentificativoUnivoco" type="stText35" minOccurs="1">
+            <xsd:element form="qualified" name="codiceIdentificativoUnivoco" type="stText35" minOccurs="1">
                 <xsd:annotation>
                     <xsd:documentation>Campo alfanumerico che può contenere il codice
                         fiscale o, in alternativa, la partita IVA del soggetto.

--- a/lib/__tests__/clients.test.ts
+++ b/lib/__tests__/clients.test.ts
@@ -1,61 +1,101 @@
-import * as clients from "../clients";
+import * as fs from 'fs';
+import 'jest-xml-matcher';
+import * as clients from '../clients';
 
-const avvisaturaHost = "avvisatura.test";
+const avvisaturaHost = 'avvisatura.test';
 const avvisaturaEndpoint = `http://${avvisaturaHost}/avvisatura/`;
 
-describe("createIscrizioniAvvisaturaClient#nodoAggiornaIscrizioniAvvisatura", () => {
-
-  it("should send the right XML", async () => {
-
-    let requestOptions;
-
-    function customReq(
-      options: any,
-      callback?: (error: any, res: any, body: any) => void
-    ): void {
-      requestOptions = options;
-      callback(null, null, null);
-    }
-
-    const iscrizioniAvvisaturaClientBase = await clients.createIscrizioniAvvisaturaClient(
-      {
-        endpoint: avvisaturaEndpoint,
-        envelopeKey: "soapenv",
-        request: customReq
-      }
-    );
-    iscrizioniAvvisaturaClientBase.addHttpHeader("Host", avvisaturaHost);
-
-    const iscrizioniAvvisaturaClient = new clients.IscrizioniAvvisaturaAsyncClient(
-      iscrizioniAvvisaturaClientBase
-    );
-
-    const input: clients.IscrizioniAvvisaturaService.InodoAggiornaIscrizioniAvvisaturaInput = {
-      datiNotifica: {
-        azioneDiAggiornamento: "A",
-        dataOraRichiesta: "2018-04-03T16:41:00",
-        identificativoMessaggioRichiesta: "1",
-        identificativoUnivocoSoggetto: {
-          codiceIdentificativoUnivoco: "FISCAL_CODE",
-          tipoIdentificativoUnivoco: "F"
+describe('createIscrizioniAvvisaturaClient#nodoAggiornaIscrizioniAvvisatura', () =>
+{
+    it('should send the right XML', async () =>
+    {
+        let requestOptions: any;
+        function customReq(
+                options: any,
+                callback?: (error: any, res: any, body: any) => void
+            ): void
+        {
+            requestOptions = options;
+            if (callback)
+            {
+                callback(null, null, null);
+            }
         }
-      },
-      identificativoCanale: "123",
-      identificativoIntermediarioPSP: "123",
-      identificativoPSP: "CDPSP",
-      password: "password"
-    };
 
-    try {
-      const output = await iscrizioniAvvisaturaClient.nodoAggiornaIscrizioniAvvisatura(
-        input
-      );
-    } catch {
-      // call will fail since customReq returns an unparsable response (null)
-      // but it's ok since we're only interester in the request object
-    }
-    expect(requestOptions.body).toEqual("xyz");
+        const iscrizioniAvvisaturaClientBase = await clients.createIscrizioniAvvisaturaClient(
+            {
+                endpoint: avvisaturaEndpoint,
+                envelopeKey: 'soapenv',
+                request: customReq,
+                xmlnsAttributes: {
+                    name: 'xmlns:sac',
+                    value: 'http://ws.pagamenti.telematici.gov/'
+                }
+            }
+        );
+        iscrizioniAvvisaturaClientBase.addHttpHeader('Host', avvisaturaHost);
 
-  });
+        // NOTE: order of fields is IMPORTANT!!! the SOAP library WILL NOT reorder
+        // the fields based on the WSDL schema!!! The order of the fields in the
+        // JSON MUST be the same of the WSDL schema!!!
 
+        const identificativoUnivocoSoggetto: clients.IscrizioniAvvisaturaService.PPTPortTypes.IidentificativoUnivocoSoggetto = {
+            tipoIdentificativoUnivoco: 'F',
+            codiceIdentificativoUnivoco: 'FISCAL_CODE'
+        };
+
+        const datiNotifica: clients.IscrizioniAvvisaturaService.PPTPortTypes.IdatiNotifica = {
+            dataOraRichiesta: '2018-04-03T16:41:00',
+            identificativoMessaggioRichiesta: '1',
+            identificativoUnivocoSoggetto: identificativoUnivocoSoggetto,
+            azioneDiAggiornamento: 'A'
+        };
+
+        const input: clients.IscrizioniAvvisaturaService.InodoAggiornaIscrizioniAvvisaturaInput = {
+            identificativoPSP: 'CDPSP',
+            identificativoIntermediarioPSP: '123',
+            identificativoCanale: '456',
+            password: 'password',
+            datiNotifica: datiNotifica
+        };
+
+        const iscrizioniAvvisaturaClient = new clients.IscrizioniAvvisaturaAsyncClient(
+            iscrizioniAvvisaturaClientBase
+        );
+
+        console.log(
+            iscrizioniAvvisaturaClientBase.describe().IscrizioniAvvisaturaService
+                .PPTPort.nodoAggiornaIscrizioniAvvisatura
+        );
+        console.log(
+            iscrizioniAvvisaturaClientBase.describe().IscrizioniAvvisaturaService
+                .PPTPort.nodoAggiornaIscrizioniAvvisatura.input.datiNotifica
+                .identificativoUnivocoSoggetto.tipoIdentificativoUnivoco
+        );
+
+        try
+        {
+            await iscrizioniAvvisaturaClient.nodoAggiornaIscrizioniAvvisatura(
+                input
+            );
+        }
+        catch
+        {
+            // call will fail since customReq returns an unparsable response (null)
+            // but it's ok since we're only interester in the request object
+        }
+
+        const expectedRequest: string = fs.readFileSync(
+            `${__dirname}/fixtures/clients.test.req1.xml`,
+            'UTF-8'
+        );
+
+        expect(requestOptions).toBeDefined();
+        if (requestOptions)
+        {
+            console.log(requestOptions.body);
+            expect(requestOptions.body).toEqualXML(expectedRequest);
+        }
+
+    });
 });

--- a/lib/__tests__/fixtures/clients.test.req1.xml
+++ b/lib/__tests__/fixtures/clients.test.req1.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns:sac="http://ws.pagamenti.telematici.gov/" xmlns:tns="http://PuntoAccessoPSP.spcoop.gov.it/servizi/IscrizioniAvvisatura">
+  <soapenv:Body>
+    <sac:nodoAggiornaIscrizioniAvvisatura xmlns:sac="http://ws.pagamenti.telematici.gov/">
+      <identificativoPSP>CDPSP</identificativoPSP>
+      <identificativoIntermediarioPSP>123</identificativoIntermediarioPSP>
+      <identificativoCanale>456</identificativoCanale>
+      <password>password</password>
+      <datiNotifica>
+        <dataOraRichiesta>2018-04-03T16:41:00</dataOraRichiesta>
+        <identificativoMessaggioRichiesta>1</identificativoMessaggioRichiesta>
+        <identificativoUnivocoSoggetto>
+          <sac:tipoIdentificativoUnivoco>F</sac:tipoIdentificativoUnivoco>
+          <sac:codiceIdentificativoUnivoco>FISCAL_CODE</sac:codiceIdentificativoUnivoco>
+        </identificativoUnivocoSoggetto>
+        <azioneDiAggiornamento>A</azioneDiAggiornamento>
+      </datiNotifica>
+    </sac:nodoAggiornaIscrizioniAvvisatura>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "danger-plugin-digitalcitizenship": "https://github.com/teamdigitale/danger-plugin-digitalcitizenship#v0.0.4"
   },
   "dependencies": {
+    "jest-xml-matcher": "^1.1.1",
     "soap": "^0.23.0"
   },
   "jest": {

--- a/wsdl-lib/AvvisiDigitaliService/PPTPort.ts
+++ b/wsdl-lib/AvvisiDigitaliService/PPTPort.ts
@@ -57,7 +57,7 @@ export namespace PPTPortTypes {
         /** http://ws.pagamenti.telematici.gov/#stISODate() */
         dataScadenzaAvviso: date;
         /** http://ws.pagamenti.telematici.gov/#stImporto(minInclusive,maxInclusive,fractionDigits,totalDigits) */
-        importoAvviso: "minInclusive" | "maxInclusive" | "fractionDigits" | "totalDigits";
+        importoAvviso: number //TODO [#158031250] wsdl-to-ts fix
         /** http://ws.pagamenti.telematici.gov/#stEMail(pattern,maxLength) */
         eMailSoggetto: string;
         /** http://ws.pagamenti.telematici.gov/#stCellulareSoggetto(pattern) */

--- a/wsdl-lib/FespPspService/PSPPort.ts
+++ b/wsdl-lib/FespPspService/PSPPort.ts
@@ -55,7 +55,7 @@ export interface IpspInviaCarrelloRPTCarteInput {
     /** http://ws.pagamenti.telematici.gov/#string(undefined) */
     esitoTransazioneCarta: string;
     /** http://ws.pagamenti.telematici.gov/#stImporto(minInclusive,maxInclusive,fractionDigits,totalDigits) */
-    importoTotalePagato: "minInclusive" | "maxInclusive" | "fractionDigits" | "totalDigits";
+    importoTotalePagato: number; //TODO [#158031250] wsdl-to-ts fix
     /** http://ws.pagamenti.telematici.gov/#stISODateTime() */
     timestampOperazione: dateTime;
     /** http://ws.pagamenti.telematici.gov/#stText6(length) */

--- a/wsdl-lib/NodoChiediElencoAvvisiDigitaliService/PPTPort.ts
+++ b/wsdl-lib/NodoChiediElencoAvvisiDigitaliService/PPTPort.ts
@@ -56,7 +56,7 @@ export namespace PPTPortTypes {
         /** http://ws.pagamenti.telematici.gov/#stISODate() */
         dataScadenzaAvviso: date;
         /** http://ws.pagamenti.telematici.gov/#stImporto(minInclusive,maxInclusive,fractionDigits,totalDigits) */
-        importoAvviso: "minInclusive" | "maxInclusive" | "fractionDigits" | "totalDigits";
+        importoAvviso: number; //TODO [#158031250] wsdl-to-ts fix
         /** http://ws.pagamenti.telematici.gov/#stText140(minLength,maxLength) */
         descrizionePagamento: string;
     }

--- a/wsdl-lib/PagamentiTelematiciPspNodoservice/PPTPort.ts
+++ b/wsdl-lib/PagamentiTelematiciPspNodoservice/PPTPort.ts
@@ -274,7 +274,7 @@ export namespace PPTPortTypes {
         /** http://ws.pagamenti.telematici.gov/#stText25(minLength,maxLength) */
         causaleSpezzone: string;
         /** http://ws.pagamenti.telematici.gov/#stImporto(minInclusive,maxInclusive,fractionDigits,totalDigits) */
-        importoSpezzone: "minInclusive" | "maxInclusive" | "fractionDigits" | "totalDigits";
+        importoSpezzone: number; //TODO: [#158031250] Fix wsdl-to-ts
     }
     export interface IspezzoniCausaleVersamento {
         /** http://ws.pagamenti.telematici.gov/#stText35(minLength,maxLength) */
@@ -283,7 +283,7 @@ export namespace PPTPortTypes {
     }
     export interface IdatiPagamentoPA {
         /** http://ws.pagamenti.telematici.gov/#stImporto(minInclusive,maxInclusive,fractionDigits,totalDigits) */
-        importoSingoloVersamento: "minInclusive" | "maxInclusive" | "fractionDigits" | "totalDigits";
+        importoSingoloVersamento: number; //TODO: [#158031250] Fix wsdl-to-ts
         /** http://ws.pagamenti.telematici.gov/#stIBANIdentifier(pattern) */
         ibanAccredito: string;
         /** http://ws.pagamenti.telematici.gov/#stBICIdentifier(pattern) */
@@ -353,7 +353,7 @@ export namespace PPTPortTypes {
     }
     export interface IdatiPagamentoPSP {
         /** http://ws.pagamenti.telematici.gov/#stImporto(minInclusive,maxInclusive,fractionDigits,totalDigits) */
-        importoSingoloVersamento: "minInclusive" | "maxInclusive" | "fractionDigits" | "totalDigits";
+        importoSingoloVersamento: number; //TODO: [#158031250] Fix wsdl-to-ts
         /** http://ws.pagamenti.telematici.gov/#stIBANIdentifier(pattern) */
         ibanAppoggio: string;
         /** http://ws.pagamenti.telematici.gov/#stBICIdentifier(pattern) */

--- a/wsdl/avvisatura/sac-common-types-1.0.xsd
+++ b/wsdl/avvisatura/sac-common-types-1.0.xsd
@@ -120,7 +120,7 @@
 
     <xsd:complexType name="ctIdentificativoUnivocoPersonaFG">
         <xsd:sequence>
-            <xsd:element name="tipoIdentificativoUnivoco" type="stTipoIdentificativoUnivocoPersFG" minOccurs="1">
+            <xsd:element form="qualified" name="tipoIdentificativoUnivoco" type="stTipoIdentificativoUnivocoPersFG" minOccurs="1">
                 <xsd:annotation>
                     <xsd:documentation>Campo alfanumerico che indica la natura del
                         soggetto, può assumere i seguenti valori:
@@ -129,7 +129,7 @@
                     <xsd:documentation>G - Persona Giuridica</xsd:documentation>
                 </xsd:annotation>
             </xsd:element>
-            <xsd:element name="codiceIdentificativoUnivoco" type="stText35" minOccurs="1">
+            <xsd:element form="qualified" name="codiceIdentificativoUnivoco" type="stText35" minOccurs="1">
                 <xsd:annotation>
                     <xsd:documentation>Campo alfanumerico che può contenere il codice
                         fiscale o, in alternativa, la partita IVA del soggetto.


### PR DESCRIPTION
wsdl-to-ts does not manage some xml attributes (e.g. on restriction attributes, minInclusive, maxInclusive...), so the generated type are incorrect.

WSDL
```
<xsd:simpleType name="stImporto">
		<xsd:restriction base="xsd:decimal">
			<xsd:minInclusive value="0.00"/>
			<xsd:maxInclusive value="99999999.99"/>
			<xsd:fractionDigits value="2"/>
			<xsd:totalDigits value="12"/>
		</xsd:restriction>
	</xsd:simpleType>
```

The generated ts type is
`importoSingoloVersamento: "minInclusive" | "maxInclusive" | "fractionDigits" | "totalDigits"`

but the expected was a number type, not a string type. 
To use italia-pagopa-api on italia-pagopa-proxy, number types for importo are needed. I've manually changed the type of importo in number, so italia-pagopa-api can be imported in italia-pagopa-proxy
The same is for all importo types. 