### PR TITLE
Impostata versione della RPT

### DIFF
--- a/wsdl/nodo/PagInf_RPT_RT_6_2_0.xsd
+++ b/wsdl/nodo/PagInf_RPT_RT_6_2_0.xsd
@@ -728,7 +728,7 @@
 	<!-- Richiesta Pagamento Telematico (RPT)-->
     <xsd:complexType name="ctRichiestaPagamentoTelematico">
 		<xsd:sequence>
-			<xsd:element name="versioneOggetto" type="pay_i:stText16" minOccurs="1">
+			<xsd:element name="versioneOggetto" type="pay_i:stText16" minOccurs="1" fixed="6.2.0">
 				<xsd:annotation>
 					<xsd:documentation>Versione che identifica l’oggetto scambiato.</xsd:documentation>
 				</xsd:annotation>


### PR DESCRIPTION
Il valore del campo versioneOggetto dovrebbe essere dettato dallo schema XSD utilizzato. Un nuova revisione della specifica potrebbe cosi pilotarne l'aggiornamento ad una versione successiva.